### PR TITLE
새로운 할인 정책 적용과 문제점

### DIFF
--- a/core/src/main/java/hello/core/order/OrderServiceImpl.java
+++ b/core/src/main/java/hello/core/order/OrderServiceImpl.java
@@ -1,7 +1,7 @@
 package hello.core.order;
 
 import hello.core.discount.DiscountPolicy;
-import hello.core.discount.FixDiscountPolicy;
+import hello.core.discount.RateDiscountPolicy;
 import hello.core.member.Member;
 import hello.core.member.MemberService;
 import hello.core.member.MemberServiceImpl;
@@ -9,13 +9,14 @@ import hello.core.member.MemberServiceImpl;
 public class OrderServiceImpl implements OrderService {
 
     private final MemberService memberService = new MemberServiceImpl();
-    private final DiscountPolicy discountPolicy = new FixDiscountPolicy();
+    //private final DiscountPolicy discountPolicy = new FixDiscountPolicy();
+    private final DiscountPolicy discountPolicy = new RateDiscountPolicy();
 
     @Override
     public Order createOrder(Long memberId, String itemName, int itemPrice) {
         Member member = memberService.findMember(memberId);
         int discountPrice = discountPolicy.discount(member, itemPrice);
-        
+
         return new Order(memberId, itemName, itemPrice, discountPrice);
     }
 }

--- a/core/src/main/java/hello/core/order/OrderServiceImpl.java
+++ b/core/src/main/java/hello/core/order/OrderServiceImpl.java
@@ -1,7 +1,6 @@
 package hello.core.order;
 
 import hello.core.discount.DiscountPolicy;
-import hello.core.discount.RateDiscountPolicy;
 import hello.core.member.Member;
 import hello.core.member.MemberService;
 import hello.core.member.MemberServiceImpl;
@@ -9,8 +8,7 @@ import hello.core.member.MemberServiceImpl;
 public class OrderServiceImpl implements OrderService {
 
     private final MemberService memberService = new MemberServiceImpl();
-    //private final DiscountPolicy discountPolicy = new FixDiscountPolicy();
-    private final DiscountPolicy discountPolicy = new RateDiscountPolicy();
+    private DiscountPolicy discountPolicy;
 
     @Override
     public Order createOrder(Long memberId, String itemName, int itemPrice) {


### PR DESCRIPTION
새로운 할인 정책 적용과 문제점 수강 완료

이번 강의에서 주문 서비스 구현체가 OCP와 DIP를 위반하는 것을 확인함
정확히는, DIP를 위반해서 OCP를 위반하게 됨.
이를 위해 DIP를 지키도록 코드를 수정하니 NPE가 발생함.

이로 인해, 객체를 생성하고 주입해주는 외부의 무언가가 필요하다는 것을 확인함.

This is closes #21 